### PR TITLE
Fix missing holidays in February 2024

### DIFF
--- a/prodcal_ics.py
+++ b/prodcal_ics.py
@@ -37,7 +37,7 @@ def get_holidays_grouped_by_months(year):
 
     for m in months:
         holidays_in_month = m.xpath(
-            ".//li[@class='calendar-list__numbers__item calendar-list__numbers__item_day-off']/text()"
+            ".//li[contains(@class, 'calendar-list__numbers__item_day-off')]/text()"
         )
         holidays_in_month = [day.strip() for day in holidays_in_month if day.strip()]
         holidays.append([int(day) for day in holidays_in_month])


### PR DESCRIPTION
Исправлены отсутствующие выходные 10 и 11 февраля 2024.

Проблема возникла из-за лишних пробелов в классе:

![image_2024-02-19_15-48-34](https://github.com/nikitastupin/prodcal_ics/assets/2442833/b17a9c80-09ed-4cc1-a519-5c6b9b5ea645)

Заменил проверку точного равенства на contains.